### PR TITLE
refactoring of common TMB functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R:
            role = c("aut", "cre"),
            email = "meixichen2010@gmail.com",
            comment = c(ORCID = "YOUR-ORCID-ID"))
-Description:  The models in this package are built using the template model builder (TMB) in R, which has the fast ability to integrate out the latent variables using Laplace approximation. This package allows the users to choose in the fit function which parameter(s) is considered as following the GP, so the users can fit spatial GEV models with different complexities to their dataset without having to write the models in TMB by themselves. This package also offers a method to sample from both fixed and random effects posterior.
+Description: The models in this package are built using the template model builder (TMB) in R, which has the fast ability to integrate out the latent variables using Laplace approximation. This package allows the users to choose in the fit function which parameter(s) is considered as following the GP, so the users can fit spatial GEV models with different complexities to their dataset without having to write the models in TMB by themselves. This package also offers a method to sample from both fixed and random effects posterior.
 License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true
@@ -25,7 +25,7 @@ Imports:
     stats
 LinkingTo: 
     TMB
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)
 Suggests: 
     testthat

--- a/inst/include/SpatialGEV/utils.hpp
+++ b/inst/include/SpatialGEV/utils.hpp
@@ -1,0 +1,72 @@
+/// @file utils.hpp
+///
+/// @brief Utilities for `SpatialGEV`.
+
+#ifndef SPATIALGEV_UTILS_HPP
+#define SPATIALGEV_UTILS_HPP
+
+/// @typedef
+/// @brief Standard typedefs for arguments to Eigen functions.
+template <class Type>
+using RefMatrix_t = Eigen::Ref <Eigen::Matrix<Type, Eigen::Dynamic, Eigen::Dynamic> >;
+template <class Type>
+using cRefMatrix_t = const Eigen::Ref <const Eigen::Matrix<Type, Eigen::Dynamic, Eigen::Dynamic> >;
+template <class Type>
+using RefVector_t = Eigen::Ref <Eigen::Matrix<Type, Eigen::Dynamic, 1> >;
+template <class Type>
+using cRefVector_t = const Eigen::Ref <const Eigen::Matrix<Type, Eigen::Dynamic, 1> >;
+template <class Type>
+using RefRowVector_t = Eigen::Ref <Eigen::Matrix<Type, 1, Eigen::Dynamic> >;
+template <class Type>
+using cRefRowVector_t = const Eigen::Ref <const Eigen::Matrix<Type, 1, Eigen::Dynamic> >;
+
+/// Calculates the log-density of the GEV distribution.
+///
+/// @param[in] x Argument to the density.
+/// @param[in] a Location parameter.
+/// @param[in] log_b Log of scale parameter.
+/// @param[in] s Shape parameter.
+///
+/// @return Log-density of GEV distribution evaluated at its inputs.
+template <class Type>
+Type gev_lpdf(Type x, Type a, Type log_b, Type s) {
+  Type log_t = log(Type(1.0) + s * (x - a) / exp(log_b));
+  return -exp(-Type(1.0) * log_t/s) - (s + Type(1.0))/s * log_t - log_b;
+  // return pow(t - Type(1.0)/s) + (s + Type(1.0))/s + log(t);
+}
+
+/// Compute the variance matrix for the square exponential kernel.
+///
+/// @param[out] cov Matrix into which to store the output.
+/// @param[in] dd Distance matrix.
+/// @param[in] sigma Scale parameter.
+/// @param[in] ell Length parameter.
+/// @param[in] sp_thres Threshold parameter.
+template <class Type>
+void cov_expo2(RefMatrix_t<Type> cov, cRefMatrix_t<Type>& dd,
+	       Type sigma, Type ell, Type sp_thres) {
+  int i,j;
+  int n = dd.rows();
+  if (sp_thres == 0){
+    cov = -dd/ell;
+    cov = cov.array().exp();
+    cov *= sigma;
+  } else {
+    // construct the covariance matrix
+    for (i = 0; i < n; i++){
+      cov(i,i) = sigma;
+      for (j = 0; j < i; j++){
+        if (dd(i,j) >= sp_thres) {
+          cov(i,j) = 0;
+          cov(j,i) = 0;
+        } else {
+          cov(i,j) = sigma*exp(-dd(i,j)/ell);  
+          cov(j,i) = cov(i,j);
+        }
+      }
+    }
+  }
+  return;
+}
+
+#endif

--- a/src/Makevars
+++ b/src/Makevars
@@ -9,7 +9,7 @@
 # Flags specifically for the TMB compilation can also be set
 # through the 'TMB_FLAGS' argument below, e.g.,
 #
-## TMB_FLAGS = -I"../../inst/include" # add include directory inst/include
+TMB_FLAGS = -std=c++11 -I"../../inst/include"
 #
 # --- TMB-specific compiling directives below ---
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -9,7 +9,7 @@
 # Flags specifically for the TMB compilation can also be set
 # through the 'TMB_FLAGS' argument below, e.g.,
 #
-## TMB_FLAGS = -I"../../inst/include" # add include directory inst/include
+TMB_FLAGS = -std=c++11 -I"../../inst/include"
 #
 # --- TMB-specific compiling directives below ---
 

--- a/src/TMB/model_a.hpp
+++ b/src/TMB/model_a.hpp
@@ -1,6 +1,8 @@
 #ifndef model_a_hpp
 #define model_a_hpp
 
+#include "SpatialGEV/utils.hpp"
+
 #undef TMB_OBJECTIVE_PTR
 #define TMB_OBJECTIVE_PTR obj
 
@@ -32,33 +34,36 @@ Type model_a(objective_function<Type>* obj) {
   
   using namespace density;
   matrix<Type> cov(n,n);
-  if (sp_thres == 0){
-    matrix<Type> tmp = -dd/ell;
-    matrix<Type> dd_exp = exp(tmp.array());
-    cov = sigma*dd_exp;
-  } else {
-    // construct the covariance matrix
-    int i,j; 
-    for (i = 0; i < n; i++){
-      cov(i,i) = sigma;
-      for (j = 0; j < i; j++){
-        Type h = dd(i,j);
-        if (h >= sp_thres) {
-          cov(i,j) = 0;
-          cov(j,i) = 0;
-        } else {
-          cov(i,j) = sigma*exp(-h/ell);  
-          cov(j,i) = cov(i,j);
-        }
-      }
-    }
-  }
+  cov_expo2<Type>(cov, dd, sigma, ell, sp_thres);
+  // if (sp_thres == 0){
+  //   matrix<Type> tmp = -dd/ell;
+  //   matrix<Type> dd_exp = exp(tmp.array());
+  //   cov = sigma*dd_exp;
+  // } else {
+  //   // construct the covariance matrix
+  //   int i,j; 
+  //   for (i = 0; i < n; i++){
+  //     cov(i,i) = sigma;
+  //     for (j = 0; j < i; j++){
+  //       Type h = dd(i,j);
+  //       if (h >= sp_thres) {
+  //         cov(i,j) = 0;
+  //         cov(j,i) = 0;
+  //       } else {
+  //         cov(i,j) = sigma*exp(-h/ell);  
+  //         cov(j,i) = cov(i,j);
+  //       }
+  //     }
+  //   }
+  // }
   
-  Type nll = n*log_b; 
+  // Type nll = n*log_b;
+  Type nll = Type(0.0);
   // the negloglik of GEV
   for(int i=0;i<n;i++) {
-    Type t = 1 + s * (y[i] - a[i]) / b;
-    nll += pow(t, -1/s) + (s + 1)/s * log(t) ;
+    // Type t = 1 + s * (y[i] - a[i]) / b;
+    // nll += pow(t, -1/s) + (s + 1)/s * log(t) ;
+    nll -= gev_lpdf<Type>(y[i], a[i], log_b, s);
   }
   
   // the negloglik of location parameter ~ MVNORM


### PR DESCRIPTION
These are now in `inst/include/SpatialGEV/utils.hpp`.  I've only done it for `model_a.hpp` but it should be done for the other models as well.